### PR TITLE
feat: replace legacy dictation with SpeechAnalyzer

### DIFF
--- a/Kaze.xcodeproj/project.pbxproj
+++ b/Kaze.xcodeproj/project.pbxproj
@@ -379,7 +379,6 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Kaze needs microphone access to transcribe your speech.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Kaze uses on-device speech recognition to convert your voice to text.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -422,7 +421,6 @@
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Kaze needs microphone access to transcribe your speech.";
-				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Kaze uses on-device speech recognition to convert your voice to text.";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/Kaze.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Kaze.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
         "branch" : "main",
-        "revision" : "064daacd07c80bc729206ccbe73fba6c85e5bed9"
+        "revision" : "5fc19fcde8aff5970ab18c974b109891479384c2"
       }
     },
     {

--- a/Kaze/App/KazeApp.swift
+++ b/Kaze/App/KazeApp.swift
@@ -10,6 +10,7 @@ struct KazeApp: App {
     var body: some Scene {
         Settings {
             ContentView(
+                appleSpeechModelManager: appDelegate.appleSpeechModelManager,
                 whisperModelManager: appDelegate.whisperModelManager,
                 parakeetModelManager: appDelegate.parakeetModelManager,
                 historyManager: appDelegate.historyManager,
@@ -27,7 +28,8 @@ struct KazeApp: App {
 
 @MainActor
 class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
-    private let speechTranscriber = SpeechTranscriber()
+    let appleSpeechModelManager = AppleSpeechModelManager()
+    private lazy var speechTranscriber = SpeechTranscriber(modelManager: appleSpeechModelManager)
     private var whisperTranscriber: WhisperTranscriber?
     private var fluidAudioTranscriber: FluidAudioTranscriber?
     let whisperModelManager = WhisperModelManager()
@@ -158,7 +160,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             formatter = TextFormatter()
         }
 
-        // Menu bar icon — use a dark/light appearance-aware icon
+        // Menu bar icon uses a dark/light appearance-aware image.
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         updateStatusBarIcon()
         if let button = statusItem?.button {
@@ -181,11 +183,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         if !UserDefaults.standard.bool(forKey: AppPreferenceKey.hasCompletedOnboarding) {
             showOnboarding()
         } else {
-            // Already completed onboarding — set up hotkey (permissions should already be granted)
+            // Already completed onboarding, so set up the hotkey (permissions should already be granted).
             Task {
                 await requestPermissionsAndSetupHotkey()
             }
         }
+    }
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        Task { await appleSpeechModelManager.refreshStatus() }
     }
 
     private func migrateLegacyPreferences() {
@@ -205,9 +211,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             defaults.set(TranscriptionEngine.parakeet.rawValue, forKey: AppPreferenceKey.transcriptionEngine)
         }
 
-        let legacyQwenDirectory = Qwen3AsrModels.defaultCacheDirectory()
-        if FileManager.default.fileExists(atPath: legacyQwenDirectory.path) {
-            try? FileManager.default.removeItem(at: legacyQwenDirectory)
+        if let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            let legacyQwenDirectory = appSupport
+                .appendingPathComponent("FluidAudio/Models/qwen3-asr-0.6b-coreml/f32", isDirectory: true)
+            if FileManager.default.fileExists(atPath: legacyQwenDirectory.path) {
+                try? FileManager.default.removeItem(at: legacyQwenDirectory)
+            }
         }
     }
 
@@ -263,6 +272,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private func observeModelState() {
         lastWhisperModelState = whisperModelManager.state
         lastParakeetModelState = parakeetModelManager.state
+
+        appleSpeechModelManager.$state
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.updateStatusItemIndicator()
+            }
+            .store(in: &cancellables)
 
         whisperModelManager.$state
             .receive(on: RunLoop.main)
@@ -320,6 +336,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     private func showOnboarding() {
         let onboardingView = OnboardingView(
+            appleSpeechModelManager: appleSpeechModelManager,
             whisperModelManager: whisperModelManager,
             parakeetModelManager: parakeetModelManager
         ) { [weak self] in
@@ -378,7 +395,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     /// Requests microphone permissions (if needed) and sets up the global hotkey.
     /// Called after onboarding completes or on subsequent launches.
     func requestPermissionsAndSetupHotkey() async {
-        // Request microphone permission silently — if already granted this returns immediately
+        // Request microphone permission silently. If already granted, this returns immediately.
         _ = await speechTranscriber.requestPermissions()
         setupHotkey()
     }
@@ -440,6 +457,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
     private func makeSettingsContent(initialTab: SettingsTab) -> AnyView {
         AnyView(ContentView(
+            appleSpeechModelManager: appleSpeechModelManager,
             whisperModelManager: whisperModelManager,
             parakeetModelManager: parakeetModelManager,
             historyManager: historyManager,
@@ -494,7 +512,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
         let started = hotkeyManager.start()
         if !started {
-            print("[Kaze] Accessibility permission not granted yet — hotkey will not work until granted.")
+            print("[Kaze] Accessibility permission not granted yet; hotkey will not work until granted.")
         }
 
         // Observe changes to hotkey mode preference (Fix #6: early-exit avoids
@@ -537,11 +555,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
         // Check if the selected engine's model is available
         if preferredEngine.requiresModelDownload && !preferredEngine.isModelReady(
+            appleManager: appleSpeechModelManager,
             whisperManager: whisperModelManager,
             parakeetManager: parakeetModelManager
         ) {
-            print("\(preferredEngine.title) model not ready, falling back to Direct Dictation")
-            engine = .dictation
+            if preferredEngine != .dictation, TranscriptionEngine.dictation.isModelReady(
+                appleManager: appleSpeechModelManager,
+                whisperManager: whisperModelManager,
+                parakeetManager: parakeetModelManager
+            ) {
+                print("\(preferredEngine.title) model not ready, falling back to Direct Dictation")
+                engine = .dictation
+            } else {
+                print("\(preferredEngine.title) model is not ready")
+                if preferredEngine == .dictation {
+                    openSettingsWindow(initialTab: .general)
+                }
+                return
+            }
         } else {
             engine = preferredEngine
         }
@@ -555,6 +586,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
         // Use the appropriate transcriber
         if engine == .whisper, engine.isModelReady(
+            appleManager: appleSpeechModelManager,
             whisperManager: whisperModelManager,
             parakeetManager: parakeetModelManager
         ) {
@@ -577,6 +609,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             overlayWindow.show(state: overlayState, notchMode: notchModeEnabled)
             whisper.startRecording()
         } else if engine == .parakeet, engine.isModelReady(
+            appleManager: appleSpeechModelManager,
             whisperManager: whisperModelManager,
             parakeetManager: parakeetModelManager
         ) {
@@ -597,7 +630,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             overlayWindow.show(state: overlayState, notchMode: notchModeEnabled)
             transcriber.startRecording()
         } else {
-            speechTranscriber.customWords = words
             speechTranscriber.selectedDeviceUID = micUID
             speechTranscriber.onTranscriptionFinished = { [weak self] (text: String) in
                 guard let self else { return }
@@ -624,7 +656,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
         if engine == .whisper {
             (session.transcriber as? WhisperTranscriber)?.stopRecording()
-            // For Whisper, transcription happens after stop — the overlay stays visible
+            // For Whisper, transcription happens after stop, so the overlay stays visible
             // until onTranscriptionFinished fires via processTranscription
             overlayState.isEnhancing = true // Show processing state while Whisper works
             overlayState.processingStatusText = processingStatusText(for: .whisper)
@@ -635,16 +667,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             overlayState.processingStatusText = processingStatusText(for: engine)
         } else {
             (session.transcriber as? SpeechTranscriber)?.stopRecording()
-            let waitingForAI = session.enhancementMode == .appleIntelligence && enhancer != nil
-            if !waitingForAI {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
-                    self?.overlayWindow.hide(state: self?.overlayState)
-                    self?.isSessionActive = false
-                    self?.activeSession = nil
-                    self?.updateStatusItemIndicator()
-                    self?.scheduleIdleModelUnload()
-                }
-            }
+            overlayState.isEnhancing = true
+            overlayState.processingStatusText = "Finalizing..."
         }
     }
 

--- a/Kaze/App/UpdaterManager.swift
+++ b/Kaze/App/UpdaterManager.swift
@@ -12,7 +12,7 @@ import Sparkle
 final class UpdaterManager: NSObject, ObservableObject {
     /// The underlying Sparkle updater controller.
     /// `startingUpdater: false` defers the initial automatic check until we
-    /// explicitly call `startUpdater()` — this avoids a race with other
+    /// explicitly call `startUpdater()`. This avoids a race with other
     /// first-launch work (permissions, onboarding).
     private let controller: SPUStandardUpdaterController
 

--- a/Kaze/Audio/MicrophoneCaptureSession.swift
+++ b/Kaze/Audio/MicrophoneCaptureSession.swift
@@ -73,6 +73,10 @@ final class MicrophoneCaptureSession: NSObject, AVCaptureAudioDataOutputSampleBu
 
             audioOutput = AVCaptureAudioDataOutput()
         }
+
+        // Ensure no captured buffers are still waiting to be delivered before callers
+        // close their transcription input stream.
+        sampleBufferQueue.sync {}
     }
 
     private func configureSession(deviceUID: String?) throws {

--- a/Kaze/Hotkeys/HotkeyManager.swift
+++ b/Kaze/Hotkeys/HotkeyManager.swift
@@ -156,7 +156,7 @@ class HotkeyManager {
                         // In key-based mode, flagsChanged only matters when the key is
                         // already held (to detect modifier release during hold-to-talk).
                         // We can't cheaply check isKeyDown here without a lock, so let
-                        // these through — they're infrequent compared to keyDown/keyUp.
+                        // these through because they're infrequent compared to keyDown/keyUp.
                         break
                     default:
                         return Unmanaged.passUnretained(event)

--- a/Kaze/Support/AppPreferences.swift
+++ b/Kaze/Support/AppPreferences.swift
@@ -47,7 +47,7 @@ enum AppPreferenceKey {
         or numbers explicitly.
         - Detect spoken cues like "new line", "next line", "new paragraph", \
         "next paragraph", "bullet point", "dash", "next item" and replace them with \
-        the corresponding formatting — remove the spoken cue word itself.
+        the corresponding formatting; remove the spoken cue word itself.
 
         Return ONLY the formatted transcription text. Nothing else.
         """

--- a/Kaze/Support/AppTypes.swift
+++ b/Kaze/Support/AppTypes.swift
@@ -20,7 +20,7 @@ enum TranscriptionEngine: String, CaseIterable, Identifiable {
 
     var description: String {
         switch self {
-        case .dictation: return "Uses Apple's built-in speech recognition. Works immediately with no setup."
+        case .dictation: return "Uses Apple's latest on-device SpeechTranscriber. The system language model may need a one-time download."
         case .whisper: return "Uses OpenAI's Whisper model running locally on your Mac. Requires a one-time download."
         case .parakeet: return "NVIDIA's Parakeet TDT 0.6B v3 via CoreML. Top-ranked accuracy, blazing fast. English only."
         }
@@ -33,26 +33,25 @@ enum TranscriptionEngine: String, CaseIterable, Identifiable {
         case .whisper:
             return "OpenAI's Whisper running locally. Multiple sizes available."
         case .dictation:
-            return "Apple's built-in speech recognition. No download required."
+            return "Apple's most accurate on-device speech model. A system-managed download may be required."
         }
     }
 
     var requiresModelDownload: Bool {
         switch self {
-        case .dictation:
-            return false
-        case .whisper, .parakeet:
+        case .dictation, .whisper, .parakeet:
             return true
         }
     }
 
     func isModelReady(
+        appleManager: AppleSpeechModelManager,
         whisperManager: WhisperModelManager,
         parakeetManager: FluidAudioModelManager
     ) -> Bool {
         switch self {
         case .dictation:
-            return true
+            return appleManager.isReady
         case .whisper:
             return whisperManager.isAvailableForTranscription
         case .parakeet:
@@ -61,12 +60,13 @@ enum TranscriptionEngine: String, CaseIterable, Identifiable {
     }
 
     func isModelDownloading(
+        appleManager: AppleSpeechModelManager,
         whisperManager: WhisperModelManager,
         parakeetManager: FluidAudioModelManager
     ) -> Bool {
         switch self {
         case .dictation:
-            return false
+            return appleManager.isDownloading
         case .whisper:
             return whisperManager.isDownloading
         case .parakeet:

--- a/Kaze/Transcription/FillerWordCleaner.swift
+++ b/Kaze/Transcription/FillerWordCleaner.swift
@@ -20,10 +20,10 @@ enum FillerWordCleaner {
         // consume the comma + optional space so the sentence reads naturally.
         //
         // Pattern explanation:
-        //   \b          – word boundary before the filler
-        //   (filler)    – one of the filler patterns
-        //   \b          – word boundary after the filler
-        //   [,;]?\s*    – optional trailing comma/semicolon and whitespace
+        //   \b          - word boundary before the filler
+        //   (filler)    - one of the filler patterns
+        //   \b          - word boundary after the filler
+        //   [,;]?\s*    - optional trailing comma/semicolon and whitespace
         for pattern in fillerPatterns {
             let regex = "\\b\(pattern)\\b[,;]?\\s*"
             result = result.replacingOccurrences(
@@ -81,12 +81,12 @@ enum FillerWordCleaner {
     /// Each pattern uses character repetition to catch elongated forms
     /// (e.g. "uhhh", "ummm") that ASR models sometimes produce.
     private static let fillerPatterns: [String] = [
-        "u+h+",          // uh, uhh, uhhh, uuhhh …
-        "u+m+",          // um, umm, ummm …
-        "e+r+m+",        // erm, errm, errrm …
-        "h+m+",          // hm, hmm, hmmm …
-        "a+h+",          // ah, ahh, ahhh …
-        "m+h+m+",        // mhm, mhmm …
-        "h+u+h+",        // huh, huhh …
+        "u+h+",          // uh, uhh, uhhh, uuhhh, etc.
+        "u+m+",          // um, umm, ummm, etc.
+        "e+r+m+",        // erm, errm, errrm, etc.
+        "h+m+",          // hm, hmm, hmmm, etc.
+        "a+h+",          // ah, ahh, ahhh, etc.
+        "m+h+m+",        // mhm, mhmm, etc.
+        "h+u+h+",        // huh, huhh, etc.
     ]
 }

--- a/Kaze/Transcription/FluidAudioTranscriber.swift
+++ b/Kaze/Transcription/FluidAudioTranscriber.swift
@@ -186,8 +186,7 @@ class FluidAudioModelManager: ObservableObject {
             case .parakeet:
                 let dir = AsrModels.defaultCacheDirectory(for: .v3)
                 let asrModels = try await AsrModels.load(from: dir, version: .v3)
-                let manager = AsrManager(config: .default)
-                try await manager.initialize(models: asrModels)
+                let manager = AsrManager(config: .default, models: asrModels)
                 await MainActor.run { parakeetManager = manager }
             }
         }
@@ -211,7 +210,8 @@ class FluidAudioModelManager: ObservableObject {
             guard let manager = parakeetManager else {
                 throw FluidAudioTranscriberError.modelNotLoaded
             }
-            let result = try await manager.transcribe(audioURL, source: .system)
+            var decoderState = try TdtDecoderState(decoderLayers: await manager.decoderLayerCount)
+            let result = try await manager.transcribe(audioURL, decoderState: &decoderState)
             return normalizeTranscript(result.text)
         }
     }

--- a/Kaze/Transcription/SpeechTranscriber.swift
+++ b/Kaze/Transcription/SpeechTranscriber.swift
@@ -4,174 +4,557 @@ import AVFoundation
 import Combine
 
 @MainActor
-class SpeechTranscriber: ObservableObject, TranscriberProtocol {
+final class AppleSpeechModelManager: ObservableObject {
+    enum ModelState: Equatable {
+        case checking
+        case notDownloaded
+        case downloading(progress: Double)
+        case ready
+        case unsupported
+        case error(String)
+    }
+
+    @Published private(set) var state: ModelState = .checking
+
+    private var downloadTask: Task<Void, Never>?
+    private var progressTask: Task<Void, Never>?
+    private var downloadGeneration: UUID?
+    private var statusGeneration = UUID()
+
+    var isReady: Bool {
+        state == .ready
+    }
+
+    var isDownloading: Bool {
+        if case .downloading = state { return true }
+        return false
+    }
+
+    init() {
+        Task { await refreshStatus() }
+    }
+
+    deinit {
+        downloadTask?.cancel()
+        progressTask?.cancel()
+    }
+
+    func refreshStatus() async {
+        guard downloadTask == nil else { return }
+        let generation = UUID()
+        statusGeneration = generation
+        state = .checking
+
+        guard Speech.SpeechTranscriber.isAvailable,
+              let locale = await Speech.SpeechTranscriber.supportedLocale(equivalentTo: .current) else {
+            guard statusGeneration == generation, downloadTask == nil else { return }
+            state = .unsupported
+            return
+        }
+
+        let module = Speech.SpeechTranscriber(locale: locale, preset: .progressiveTranscription)
+        let status = await AssetInventory.status(forModules: [module])
+        guard statusGeneration == generation, downloadTask == nil else { return }
+        switch status {
+        case .installed:
+            state = .ready
+        case .unsupported:
+            state = .unsupported
+        case .supported:
+            state = .notDownloaded
+        case .downloading:
+            state = .notDownloaded
+        @unknown default:
+            state = .notDownloaded
+        }
+    }
+
+    func downloadModel() async {
+        guard downloadTask == nil else { return }
+
+        let generation = UUID()
+        statusGeneration = generation
+        downloadGeneration = generation
+
+        downloadTask = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                if self.downloadGeneration == generation {
+                    self.progressTask?.cancel()
+                    self.progressTask = nil
+                    self.downloadTask = nil
+                    self.downloadGeneration = nil
+                }
+            }
+
+            guard Speech.SpeechTranscriber.isAvailable,
+                  let locale = await Speech.SpeechTranscriber.supportedLocale(equivalentTo: .current) else {
+                self.state = .unsupported
+                return
+            }
+
+            let module = Speech.SpeechTranscriber(locale: locale, preset: .progressiveTranscription)
+            do {
+                guard let request = try await AssetInventory.assetInstallationRequest(supporting: [module]) else {
+                    self.state = .ready
+                    return
+                }
+
+                self.state = .downloading(progress: 0)
+                self.progressTask = Task { [weak self, progress = request.progress] in
+                    while !Task.isCancelled {
+                        self?.state = .downloading(progress: progress.fractionCompleted)
+                        try? await Task.sleep(for: .milliseconds(150))
+                    }
+                }
+
+                try await request.downloadAndInstall()
+                guard !Task.isCancelled else { return }
+                guard self.downloadGeneration == generation else { return }
+                self.state = .ready
+            } catch is CancellationError {
+                guard self.downloadGeneration == generation else { return }
+                await self.refreshStatus()
+            } catch {
+                guard self.downloadGeneration == generation else { return }
+                self.state = .error(error.localizedDescription)
+            }
+        }
+
+        await downloadTask?.value
+    }
+
+    func cancelDownload() {
+        statusGeneration = UUID()
+        downloadGeneration = nil
+        downloadTask?.cancel()
+        downloadTask = nil
+        progressTask?.cancel()
+        progressTask = nil
+        Task { await refreshStatus() }
+    }
+
+    func makeTranscriber() async throws -> Speech.SpeechTranscriber {
+        guard let locale = await Speech.SpeechTranscriber.supportedLocale(equivalentTo: .current) else {
+            throw AppleSpeechError.unsupportedLocale
+        }
+        let module = Speech.SpeechTranscriber(locale: locale, preset: .progressiveTranscription)
+        guard await AssetInventory.status(forModules: [module]) == .installed else {
+            state = .notDownloaded
+            throw AppleSpeechError.modelNotInstalled
+        }
+        state = .ready
+        return module
+    }
+}
+
+private enum AppleSpeechError: LocalizedError {
+    case unsupportedLocale
+    case modelNotInstalled
+    case unavailableAudioFormat
+    case audioConversionFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedLocale:
+            return "Apple Speech does not support the current language."
+        case .modelNotInstalled:
+            return "The Apple Speech model is not installed."
+        case .unavailableAudioFormat:
+            return "Apple Speech could not select a compatible audio format."
+        case .audioConversionFailed:
+            return "Kaze could not convert microphone audio for Apple Speech."
+        }
+    }
+}
+
+@MainActor
+final class SpeechTranscriber: ObservableObject, TranscriberProtocol {
     @Published var isRecording = false
     @Published var audioLevel: Float = 0.0
     @Published var transcribedText = ""
     @Published var isEnhancing = false
 
-    private var speechRecognizer: SFSpeechRecognizer?
-    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
-    private var recognitionTask: SFSpeechRecognitionTask?
-    private let microphoneCapture = MicrophoneCaptureSession()
-
-    private var finalizeTimeoutTask: Task<Void, Never>?
-    private var hasDeliveredFinalResult = false
-
     var onTranscriptionFinished: ((String) -> Void)?
     var selectedDeviceUID: String?
 
-    /// Custom words to hint the recognizer toward (names, abbreviations, etc.)
-    var customWords: [String] = []
+    private let modelManager: AppleSpeechModelManager
+    private let microphoneCapture = MicrophoneCaptureSession()
 
-    init() {
-        speechRecognizer = SFSpeechRecognizer(locale: Locale.current)
+    private var analyzer: SpeechAnalyzer?
+    private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
+    private var resultsTask: Task<Void, Never>?
+    private var setupTask: Task<Void, Never>?
+    private var finalizationTask: Task<Void, Never>?
+    private var finalizedTranscript = ""
+    private var volatileTranscript = ""
+    private var hasDeliveredFinalResult = false
+    private var stopRequested = false
+    private var analyzerStarted = false
+    private var inputPipeline: AppleSpeechInputPipeline?
+
+    init(modelManager: AppleSpeechModelManager) {
+        self.modelManager = modelManager
     }
 
     deinit {
+        setupTask?.cancel()
+        resultsTask?.cancel()
+        finalizationTask?.cancel()
         let capture = microphoneCapture
         Task { @MainActor in capture.stop() }
     }
 
     func requestPermissions() async -> Bool {
-        let speechStatus = await withCheckedContinuation { continuation in
-            SFSpeechRecognizer.requestAuthorization { status in
-                continuation.resume(returning: status)
-            }
-        }
-        guard speechStatus == .authorized else { return false }
-
-        let micStatus = await AVCaptureDevice.requestAccess(for: .audio)
-        return micStatus
+        await AVCaptureDevice.requestAccess(for: .audio)
     }
 
     func startRecording() {
         guard !isRecording else { return }
-        guard let recognizer = speechRecognizer, recognizer.isAvailable else { return }
+        guard modelManager.isReady else {
+            print("Apple Speech model is not ready")
+            return
+        }
 
         cleanupSessionState()
         transcribedText = ""
+        finalizedTranscript = ""
+        volatileTranscript = ""
         audioLevel = 0
         hasDeliveredFinalResult = false
+        stopRequested = false
+        analyzerStarted = false
+        isRecording = true
 
-        do {
-            try startSpeechRecognition(recognizer: recognizer)
-            isRecording = true
-        } catch {
-            print("Failed to start recording: \(error)")
-            cleanupSessionState()
-        }
-    }
-
-    func stopRecording() {
-        guard isRecording else { return }
-
-        stopAudioCapture()
-        isRecording = false
-
-        finalizeTimeoutTask?.cancel()
-        finalizeTimeoutTask = Task { [weak self] in
-            try? await Task.sleep(for: .milliseconds(900))
-            await MainActor.run {
-                self?.forceFinalizeIfNeeded()
-            }
-        }
-    }
-
-    private func cleanupSessionState() {
-        finalizeTimeoutTask?.cancel()
-        finalizeTimeoutTask = nil
-
-        recognitionTask?.cancel()
-        recognitionTask = nil
-        recognitionRequest = nil
-    }
-
-    private func stopAudioCapture() {
+        let pipeline = AppleSpeechInputPipeline()
+        inputPipeline = pipeline
         microphoneCapture.stop()
-        recognitionRequest?.endAudio()
-    }
+        microphoneCapture.onAudioChunk = { [weak self, pipeline] chunk in
+            pipeline.consume(samples: chunk.monoSamples, sampleRate: chunk.sampleRate)
 
-    private func forceFinalizeIfNeeded() {
-        guard !hasDeliveredFinalResult else { return }
-        finishRecognition(with: transcribedText)
-    }
-
-    private func finishRecognition(with text: String) {
-        guard !hasDeliveredFinalResult else { return }
-        hasDeliveredFinalResult = true
-
-        finalizeTimeoutTask?.cancel()
-        finalizeTimeoutTask = nil
-
-        recognitionTask?.cancel()
-        recognitionTask = nil
-        recognitionRequest = nil
-
-        onTranscriptionFinished?(text.trimmingCharacters(in: .whitespacesAndNewlines))
-    }
-
-    private func startSpeechRecognition(recognizer: SFSpeechRecognizer) throws {
-        recognitionTask?.cancel()
-        recognitionTask = nil
-        recognitionRequest = nil
-
-        let request = SFSpeechAudioBufferRecognitionRequest()
-        request.shouldReportPartialResults = true
-        request.taskHint = .dictation
-        if !customWords.isEmpty {
-            request.contextualStrings = customWords
-        }
-        recognitionRequest = request
-        microphoneCapture.stop()
-        microphoneCapture.onAudioChunk = { [weak self, weak request] chunk in
-            request?.appendAudioSampleBuffer(chunk.sampleBuffer)
             let normalized = Self.normalizedAudioLevel(from: chunk.monoSamples)
             Task { @MainActor [weak self] in
                 self?.audioLevel = normalized
             }
         }
-        try microphoneCapture.start(deviceUID: selectedDeviceUID)
 
-        recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+        do {
+            try microphoneCapture.start(deviceUID: selectedDeviceUID)
+        } catch {
+            print("Apple Speech microphone capture failed: \(error)")
+            isRecording = false
+            finishRecognition(with: "")
+            return
+        }
+
+        setupTask = Task { [weak self] in
             guard let self else { return }
-
-            if let result {
-                let text = result.bestTranscription.formattedString
-                Task { @MainActor in
-                    self.transcribedText = text
-                    if result.isFinal {
-                        self.finishRecognition(with: text)
-                    }
-                }
-            }
-
-            if let error {
-                let nsError = error as NSError
-                if nsError.domain != "kAFAssistantErrorDomain" || (nsError.code != 216 && nsError.code != 1110) {
-                    print("Recognition error: \(error)")
-                }
-
-                Task { @MainActor in
-                    if nsError.domain == "kAFAssistantErrorDomain" && nsError.code == 1110 {
-                        self.finishRecognition(with: "")
-                        return
-                    }
-
-                    self.finishRecognition(with: self.transcribedText)
-                }
+            do {
+                try await self.startSpeechAnalysis()
+            } catch is CancellationError {
+            } catch {
+                print("Apple Speech failed to start: \(error)")
+                self.microphoneCapture.stop()
+                self.isRecording = false
+                self.finishRecognition(with: self.transcribedText)
             }
         }
     }
 
+    func stopRecording() {
+        guard isRecording else { return }
+        stopRequested = true
+        microphoneCapture.stop()
+        isRecording = false
+        inputPipeline?.finish()
+
+        guard analyzerStarted, let analyzer else { return }
+        finalize(analyzer)
+    }
+
+    private func finalize(_ analyzer: SpeechAnalyzer) {
+        guard finalizationTask == nil else { return }
+        finalizationTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await analyzer.finalizeAndFinishThroughEndOfInput()
+                await self.resultsTask?.value
+            } catch is CancellationError {
+            } catch {
+                print("Apple Speech finalization failed: \(error)")
+            }
+            self.finishRecognition(with: self.currentTranscript)
+        }
+    }
+
+    private func startSpeechAnalysis() async throws {
+        let module = try await modelManager.makeTranscriber()
+        guard let analyzerFormat = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [module]) else {
+            throw AppleSpeechError.unavailableAudioFormat
+        }
+
+        let analyzer = SpeechAnalyzer(modules: [module])
+        let (inputSequence, continuation) = AsyncStream.makeStream(of: AnalyzerInput.self)
+        self.analyzer = analyzer
+        inputContinuation = continuation
+
+        resultsTask = Task { [weak self] in
+            do {
+                for try await result in module.results {
+                    guard let self else { return }
+                    let text = String(result.text.characters)
+                    if result.isFinal {
+                        self.finalizedTranscript = Self.appending(text, to: self.finalizedTranscript)
+                        self.volatileTranscript = ""
+                    } else {
+                        self.volatileTranscript = text
+                    }
+                    self.transcribedText = self.currentTranscript
+                }
+            } catch is CancellationError {
+            } catch {
+                print("Apple Speech results failed: \(error)")
+            }
+        }
+
+        try await analyzer.prepareToAnalyze(in: analyzerFormat)
+        try await analyzer.start(inputSequence: inputSequence)
+        analyzerStarted = true
+
+        if stopRequested {
+            inputPipeline?.attach(analyzerFormat: analyzerFormat, continuation: continuation)
+            inputPipeline?.finish()
+            finalize(analyzer)
+            return
+        }
+
+        inputPipeline?.attach(analyzerFormat: analyzerFormat, continuation: continuation)
+    }
+
+    private var currentTranscript: String {
+        Self.appending(volatileTranscript, to: finalizedTranscript)
+    }
+
+    private func cleanupSessionState() {
+        setupTask?.cancel()
+        setupTask = nil
+        resultsTask?.cancel()
+        resultsTask = nil
+        finalizationTask?.cancel()
+        finalizationTask = nil
+        inputContinuation?.finish()
+        inputContinuation = nil
+        if let analyzer {
+            Task { await analyzer.cancelAndFinishNow() }
+        }
+        analyzer = nil
+        analyzerStarted = false
+        inputPipeline = nil
+    }
+
+    private func finishRecognition(with text: String) {
+        guard !hasDeliveredFinalResult else { return }
+        hasDeliveredFinalResult = true
+        let finalText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        cleanupSessionState()
+        onTranscriptionFinished?(finalText)
+    }
+
+    private nonisolated static func appending(_ text: String, to existing: String) -> String {
+        let text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else { return existing }
+        guard !existing.isEmpty else { return text }
+        return existing + " " + text
+    }
+
+    fileprivate nonisolated static func makePCMBuffer(samples: [Float], sampleRate: Double) throws -> AVAudioPCMBuffer {
+        guard !samples.isEmpty,
+              let sourceFormat = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: sampleRate,
+                channels: 1,
+                interleaved: false
+              ),
+              let sourceBuffer = AVAudioPCMBuffer(
+                pcmFormat: sourceFormat,
+                frameCapacity: AVAudioFrameCount(samples.count)
+              ) else {
+            throw AppleSpeechError.audioConversionFailed
+        }
+
+        sourceBuffer.frameLength = sourceBuffer.frameCapacity
+        samples.withUnsafeBufferPointer { source in
+            sourceBuffer.floatChannelData?[0].update(from: source.baseAddress!, count: samples.count)
+        }
+
+        return sourceBuffer
+    }
+
     private nonisolated static func normalizedAudioLevel(from samples: [Float]) -> Float {
         guard !samples.isEmpty else { return 0 }
-
         var rms: Float = 0
         for sample in samples {
             rms += sample * sample
         }
         rms = sqrt(rms / Float(samples.count))
         return min(rms * 20, 1.0)
+    }
+}
+
+private final class AppleSpeechInputPipeline: @unchecked Sendable {
+    private struct PendingChunk {
+        let samples: [Float]
+        let sampleRate: Double
+    }
+
+    private let lock = NSLock()
+    private var pendingChunks: [PendingChunk] = []
+    private var pendingDuration: TimeInterval = 0
+    private var converter: AppleSpeechAudioConverter?
+    private var continuation: AsyncStream<AnalyzerInput>.Continuation?
+    private var isFinished = false
+
+    func consume(samples: [Float], sampleRate: Double) {
+        lock.withLock {
+            guard !isFinished else { return }
+            guard let converter, let continuation else {
+                pendingChunks.append(PendingChunk(samples: samples, sampleRate: sampleRate))
+                pendingDuration += Double(samples.count) / sampleRate
+                while pendingDuration > 10, !pendingChunks.isEmpty {
+                    let removed = pendingChunks.removeFirst()
+                    pendingDuration -= Double(removed.samples.count) / removed.sampleRate
+                }
+                return
+            }
+            yield(samples: samples, sampleRate: sampleRate, converter: converter, continuation: continuation)
+        }
+    }
+
+    func attach(analyzerFormat: AVAudioFormat, continuation: AsyncStream<AnalyzerInput>.Continuation) {
+        lock.withLock {
+            guard self.continuation == nil else { return }
+            let converter = AppleSpeechAudioConverter(analyzerFormat: analyzerFormat)
+            self.converter = converter
+            self.continuation = continuation
+            for chunk in pendingChunks {
+                yield(samples: chunk.samples, sampleRate: chunk.sampleRate, converter: converter, continuation: continuation)
+            }
+            pendingChunks.removeAll()
+            pendingDuration = 0
+            if isFinished {
+                flushAndFinish(converter: converter, continuation: continuation)
+            }
+        }
+    }
+
+    func finish() {
+        lock.withLock {
+            guard !isFinished else { return }
+            isFinished = true
+            if let converter, let continuation {
+                flushAndFinish(converter: converter, continuation: continuation)
+                pendingChunks.removeAll()
+                pendingDuration = 0
+            }
+        }
+    }
+
+    private func flushAndFinish(
+        converter: AppleSpeechAudioConverter,
+        continuation: AsyncStream<AnalyzerInput>.Continuation
+    ) {
+        do {
+            for input in try converter.flush() {
+                continuation.yield(input)
+            }
+        } catch {
+            print("Apple Speech audio flush failed: \(error)")
+        }
+        continuation.finish()
+    }
+
+    private func yield(
+        samples: [Float],
+        sampleRate: Double,
+        converter: AppleSpeechAudioConverter,
+        continuation: AsyncStream<AnalyzerInput>.Continuation
+    ) {
+        do {
+            for input in try converter.convert(samples: samples, sampleRate: sampleRate) {
+                continuation.yield(input)
+            }
+        } catch {
+            print("Apple Speech audio conversion failed: \(error)")
+        }
+    }
+}
+
+private final class AppleSpeechAudioConverter: @unchecked Sendable {
+    private let analyzerFormat: AVAudioFormat
+    private var sourceFormat: AVAudioFormat?
+    private var converter: AVAudioConverter?
+
+    init(analyzerFormat: AVAudioFormat) {
+        self.analyzerFormat = analyzerFormat
+    }
+
+    func convert(samples: [Float], sampleRate: Double) throws -> [AnalyzerInput] {
+        let sourceBuffer = try SpeechTranscriber.makePCMBuffer(samples: samples, sampleRate: sampleRate)
+        if sourceBuffer.format == analyzerFormat {
+            return [AnalyzerInput(buffer: sourceBuffer)]
+        }
+
+        if sourceFormat != sourceBuffer.format {
+            sourceFormat = sourceBuffer.format
+            converter = AVAudioConverter(from: sourceBuffer.format, to: analyzerFormat)
+        }
+        guard let converter else { throw AppleSpeechError.audioConversionFailed }
+
+        let outputCapacity = AVAudioFrameCount(
+            ceil(Double(sourceBuffer.frameLength) * analyzerFormat.sampleRate / sourceBuffer.format.sampleRate)
+        ) + 16
+        guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: analyzerFormat, frameCapacity: outputCapacity) else {
+            throw AppleSpeechError.audioConversionFailed
+        }
+
+        var suppliedInput = false
+        var conversionError: NSError?
+        let status = converter.convert(to: outputBuffer, error: &conversionError) { _, inputStatus in
+            if suppliedInput {
+                inputStatus.pointee = .noDataNow
+                return nil
+            }
+            suppliedInput = true
+            inputStatus.pointee = .haveData
+            return sourceBuffer
+        }
+        guard status != .error, conversionError == nil else {
+            throw conversionError ?? AppleSpeechError.audioConversionFailed
+        }
+        guard outputBuffer.frameLength > 0 else { return [] }
+        return [AnalyzerInput(buffer: outputBuffer)]
+    }
+
+    func flush() throws -> [AnalyzerInput] {
+        guard let converter else { return [] }
+        var inputs: [AnalyzerInput] = []
+
+        while true {
+            guard let outputBuffer = AVAudioPCMBuffer(pcmFormat: analyzerFormat, frameCapacity: 1024) else {
+                throw AppleSpeechError.audioConversionFailed
+            }
+            var conversionError: NSError?
+            let status = converter.convert(to: outputBuffer, error: &conversionError) { _, inputStatus in
+                inputStatus.pointee = .endOfStream
+                return nil
+            }
+            if let conversionError { throw conversionError }
+            if outputBuffer.frameLength > 0 {
+                inputs.append(AnalyzerInput(buffer: outputBuffer))
+            }
+            if status == .endOfStream || outputBuffer.frameLength == 0 { break }
+        }
+
+        return inputs
     }
 }

--- a/Kaze/Transcription/WhisperTranscriber.swift
+++ b/Kaze/Transcription/WhisperTranscriber.swift
@@ -363,7 +363,7 @@ class WhisperTranscriber: ObservableObject, TranscriberProtocol {
     }
 
     func requestPermissions() async -> Bool {
-        // Whisper only needs microphone access (no SFSpeechRecognizer authorization needed)
+        // On-device engines only need microphone access.
         let micStatus = await AVCaptureDevice.requestAccess(for: .audio)
         return micStatus
     }

--- a/Kaze/Views/Onboarding/OnboardingView.swift
+++ b/Kaze/Views/Onboarding/OnboardingView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import AppKit
 import Carbon
 import AVFoundation
-import Speech
 
 // MARK: - Onboarding View
 
@@ -19,6 +18,7 @@ struct OnboardingView: View {
     @State private var activePermissionRequests = Set<PermissionKind>()
 
     // Model managers
+    @ObservedObject var appleSpeechModelManager: AppleSpeechModelManager
     @ObservedObject var whisperModelManager: WhisperModelManager
     @ObservedObject var parakeetModelManager: FluidAudioModelManager
     @StateObject private var hotkeyRecorder = HotkeyShortcutRecorder()
@@ -44,6 +44,7 @@ struct OnboardingView: View {
     /// Whether the selected model is currently downloading.
     private var isModelDownloading: Bool {
         selectedEngine.isModelDownloading(
+            appleManager: appleSpeechModelManager,
             whisperManager: whisperModelManager,
             parakeetManager: parakeetModelManager
         )
@@ -52,6 +53,7 @@ struct OnboardingView: View {
     /// Whether the selected model has been downloaded (or doesn't need one).
     private var isModelReady: Bool {
         selectedEngine.isModelReady(
+            appleManager: appleSpeechModelManager,
             whisperManager: whisperModelManager,
             parakeetManager: parakeetModelManager
         )
@@ -93,7 +95,7 @@ struct OnboardingView: View {
                     Button("Back") {
                         hotkeyRecorder.stop()
                         if currentStep == 5 && !selectedEngine.requiresModelDownload {
-                            // Skipped model download step — go back to engine selection
+                            // Skipped model download step, go back to engine selection.
                             currentStep = 3
                         } else {
                             currentStep -= 1
@@ -122,7 +124,7 @@ struct OnboardingView: View {
                     .keyboardShortcut(.return, modifiers: [])
                     .controlSize(.regular)
                     .buttonStyle(.borderedProminent)
-                    .disabled(currentStep == 4 && isModelDownloading) // Can't advance during download
+                    .disabled(currentStep == 4 && (!isModelReady || isModelDownloading))
                 } else {
                     Button("Get Started") {
                         hotkeyShortcut.saveToDefaults()
@@ -536,7 +538,7 @@ struct OnboardingView: View {
             Text("Download Model")
                 .font(.title2.bold())
 
-            Text("\(selectedEngine.title) requires a model download.\nThis only needs to happen once.")
+            Text("\(selectedEngine.title) requires a one-time model download.\nThis only needs to happen once.")
                 .font(.body)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -555,14 +557,66 @@ struct OnboardingView: View {
     @ViewBuilder
     private var modelDownloadStatusView: some View {
         switch selectedEngine {
+        case .dictation:
+            onboardingAppleSpeechStatus
         case .whisper:
             onboardingWhisperStatus
         case .parakeet:
             onboardingFluidAudioStatus(manager: parakeetModelManager, model: .parakeet)
-        default:
-            Text("No download required.")
+        }
+    }
+
+    @ViewBuilder
+    private var onboardingAppleSpeechStatus: some View {
+        switch appleSpeechModelManager.state {
+        case .checking:
+            VStack(spacing: 8) {
+                ProgressView()
+                Text("Checking the system model...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        case .notDownloaded:
+            VStack(spacing: 10) {
+                Text("Apple Speech system model")
+                    .font(.system(size: 13, weight: .medium))
+                Button("Download Model") {
+                    Task { await appleSpeechModelManager.downloadModel() }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+            }
+        case .downloading(let progress):
+            VStack(spacing: 8) {
+                ProgressView(value: progress)
+                    .frame(maxWidth: 240)
+                Text("\(Int(progress * 100))%")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                Button("Cancel", role: .destructive) {
+                    appleSpeechModelManager.cancelDownload()
+                }
+                .controlSize(.small)
+            }
+        case .ready:
+            Label("System model ready", systemImage: "checkmark.circle.fill")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.green)
+        case .unsupported:
+            Label("Apple Speech does not support this Mac or system language.", systemImage: "exclamationmark.triangle.fill")
                 .font(.caption)
-                .foregroundStyle(.secondary)
+                .foregroundStyle(.red)
+        case .error(let message):
+            VStack(spacing: 8) {
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                Button("Retry") {
+                    Task { await appleSpeechModelManager.downloadModel() }
+                }
+                .controlSize(.small)
+            }
         }
     }
 

--- a/Kaze/Views/Settings/ContentView.swift
+++ b/Kaze/Views/Settings/ContentView.swift
@@ -56,6 +56,7 @@ private enum AppVersion {
 // MARK: - Root View
 
 struct ContentView: View {
+    @ObservedObject var appleSpeechModelManager: AppleSpeechModelManager
     @ObservedObject var whisperModelManager: WhisperModelManager
     @ObservedObject var parakeetModelManager: FluidAudioModelManager
     @ObservedObject var historyManager: TranscriptionHistoryManager
@@ -66,6 +67,7 @@ struct ContentView: View {
     @State private var selectedTab: SettingsTab? = .general
 
     init(
+        appleSpeechModelManager: AppleSpeechModelManager,
         whisperModelManager: WhisperModelManager,
         parakeetModelManager: FluidAudioModelManager,
         historyManager: TranscriptionHistoryManager,
@@ -74,6 +76,7 @@ struct ContentView: View {
         restartOnboarding: @escaping () -> Void,
         initialTab: SettingsTab = .general
     ) {
+        self.appleSpeechModelManager = appleSpeechModelManager
         self.whisperModelManager = whisperModelManager
         self.parakeetModelManager = parakeetModelManager
         self.historyManager = historyManager
@@ -115,6 +118,7 @@ struct ContentView: View {
         switch tab {
         case .general:
             GeneralSettingsView(
+                appleSpeechModelManager: appleSpeechModelManager,
                 whisperModelManager: whisperModelManager,
                 parakeetModelManager: parakeetModelManager
             )
@@ -246,6 +250,7 @@ private struct GeneralSettingsView: View {
     @State private var availableMicrophones: [AudioInputDevice] = []
     @StateObject private var audioDeviceObserver = AudioDeviceObserver()
 
+    @ObservedObject var appleSpeechModelManager: AppleSpeechModelManager
     @ObservedObject var whisperModelManager: WhisperModelManager
     @ObservedObject var parakeetModelManager: FluidAudioModelManager
 
@@ -277,6 +282,10 @@ private struct GeneralSettingsView: View {
                 Text(selectedEngine.description)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+
+                if selectedEngine == .dictation {
+                    appleSpeechModelStatusRow
+                }
 
                 if selectedEngine == .whisper {
                     Picker("Whisper model", selection: Binding(
@@ -363,6 +372,59 @@ private struct GeneralSettingsView: View {
     }
 
     // MARK: - Whisper Model Status
+
+    @ViewBuilder
+    private var appleSpeechModelStatusRow: some View {
+        switch appleSpeechModelManager.state {
+        case .checking:
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Checking system model...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        case .notDownloaded:
+            HStack(spacing: 8) {
+                Text("System model not downloaded")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Button("Download") {
+                    Task { await appleSpeechModelManager.downloadModel() }
+                }
+                .controlSize(.small)
+            }
+        case .downloading(let progress):
+            HStack(spacing: 8) {
+                ProgressView(value: progress).frame(maxWidth: 140)
+                Text("\(Int(progress * 100))%")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                Button("Cancel", role: .destructive) {
+                    appleSpeechModelManager.cancelDownload()
+                }
+                .controlSize(.small)
+            }
+        case .ready:
+            Label("System model ready", systemImage: "checkmark.circle.fill")
+                .font(.caption)
+                .foregroundStyle(.green)
+        case .unsupported:
+            Label("Apple Speech does not support this Mac or system language.", systemImage: "exclamationmark.triangle.fill")
+                .font(.caption)
+                .foregroundStyle(.red)
+        case .error(let message):
+            HStack(spacing: 8) {
+                Label(message, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                Button("Retry") {
+                    Task { await appleSpeechModelManager.downloadModel() }
+                }
+                .controlSize(.small)
+            }
+        }
+    }
 
     @ViewBuilder
     private var whisperModelStatusRow: some View {
@@ -1436,7 +1498,7 @@ private struct VocabularySettingsView: View {
                     Text("No custom words yet")
                         .font(.body)
                         .foregroundStyle(.secondary)
-                    Text("Add names, abbreviations, and specialised terms.\nKaze will recognise them during transcription.")
+                    Text("Add names, abbreviations, and specialised terms.\nWhisper uses them during transcription; AI enhancement preserves their spelling.")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                         .multilineTextAlignment(.center)

--- a/Kaze/Views/Shared/WaveformView.swift
+++ b/Kaze/Views/Shared/WaveformView.swift
@@ -27,7 +27,7 @@ struct WaveformView: View {
     private var cornerRadius: CGFloat { isCompact ? 24 : 20 }
     private var textOverflows: Bool { transcribedText.count > 38 }
 
-    // Notch mode corner radii — fixed so width never shifts
+    // Notch mode corner radii are fixed so width never shifts.
     private let notchTopCornerRadius: CGFloat = 8
     private let notchBottomCornerRadius: CGFloat = 10
 
@@ -157,7 +157,7 @@ struct WaveformView: View {
     }
 
     /// Width of the notch content.
-    /// Fixed width — only height changes when text appears.
+    /// Fixed width; only height changes when text appears.
     private var notchContentWidth: CGFloat {
         notchVisible ? 280 : 0
     }
@@ -313,7 +313,7 @@ struct WaveformView: View {
         }
     }
 
-    /// Gentle wave pattern for processing bars — subtle, low variance
+    /// Gentle wave pattern for processing bars with subtle, low variance.
     private func processingBarHeight(for index: Int) -> CGFloat {
         let phase = phases[index]
         let sine = (sin(phase) + 1) / 2

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ The app lives entirely in the menu bar with no Dock icon. On first launch, a gui
 
 > **Personal recommendation** -- use **Parakeet v3 (NVIDIA)** for the best overall results.
 
-Kaze ships with **4 fully on-device transcription engines**:
+Kaze ships with **3 fully on-device transcription engines**:
 
 | Engine | Framework | Notes |
 |---|---|---|
-| **Direct Dictation** | Apple `SFSpeechRecognizer` | Zero setup, real-time streaming, uses device locale |
+| **Direct Dictation** | Apple `SpeechAnalyzer` + `SpeechTranscriber` | Real-time streaming, uses device locale and a system-managed model |
 | **Whisper (OpenAI)** | [WhisperKit](https://github.com/argmaxinc/WhisperKit) | Local model variants: Tiny, Base, Small, Large v3 Turbo |
 | **Parakeet v3 (NVIDIA)** | [FluidAudio](https://github.com/FluidInference/FluidAudio) | Fast, high-accuracy English ASR (~600 MB CoreML model) |
 
@@ -36,7 +36,7 @@ Kaze ships with **4 fully on-device transcription engines**:
 - **One-click download/remove** in Settings -- view readiness status and model size on disk
 - **Cancel in-progress downloads** at any time
 - **Idle model unloading** -- models automatically free memory after 90 seconds of inactivity
-- **Graceful fallback** -- if a selected model is unavailable, Kaze falls back to Direct Dictation
+- **Graceful fallback** -- if a selected model is unavailable and Direct Dictation is ready, Kaze falls back to it
 
 ### Recording overlay
 
@@ -68,12 +68,12 @@ Kaze ships with **4 fully on-device transcription engines**:
 
 ### Onboarding
 
-- **4-step guided setup** on first launch: Welcome, Hotkey configuration, Engine selection, and Completion summary
+- **6-step guided setup** on first launch: Welcome, permissions, hotkey configuration, engine selection, model download, and completion summary
 - Preferences are saved automatically as you complete each step
 
 ### Other features
 
-- **Custom vocabulary/keywords** -- add names, abbreviations, and domain terms to improve recognition across all engines
+- **Custom vocabulary/keywords** -- improve Whisper recognition and preserve exact spelling during AI enhancement
 - **Transcription history** -- persistent local history (latest 50 entries) with engine labels, "Enhanced" badge, relative timestamps, and one-click copy
 - **Clipboard-safe auto-paste** -- saves and restores your clipboard contents around each paste
 - **Trailing space option** -- optionally append a space after each transcription
@@ -86,7 +86,7 @@ Kaze ships with **4 fully on-device transcription engines**:
 | Layer | Technology |
 |---|---|
 | UI | **SwiftUI** + **AppKit** -- SwiftUI for Settings/Onboarding/Overlay views; AppKit for menu bar, floating panel, clipboard, and simulated key events |
-| Speech | **Apple Speech framework** (`SFSpeechRecognizer`) for real-time streaming dictation |
+| Speech | **Apple Speech framework** (`SpeechAnalyzer` + `SpeechTranscriber`) for on-device real-time dictation |
 | Whisper | [**WhisperKit**](https://github.com/argmaxinc/WhisperKit) for local OpenAI Whisper transcription |
 | Parakeet | [**FluidAudio**](https://github.com/FluidInference/FluidAudio) for Parakeet v3 CoreML runtime |
 | Enhancement | **Foundation Models** (Apple Intelligence on-device LLM) for text cleanup |
@@ -101,7 +101,6 @@ Kaze ships with **4 fully on-device transcription engines**:
 - Xcode 26+ (for building from source)
 - Accessibility permission (for global hotkey)
 - Microphone permission
-- Speech Recognition permission (used by Direct Dictation)
 
 ## Building from source
 


### PR DESCRIPTION
## Summary

- replace the legacy `SFSpeechRecognizer` Direct Dictation path with Apple's on-device `SpeechAnalyzer` and `SpeechTranscriber`
- add system speech-model readiness, download progress, cancellation, and error states to onboarding and Settings
- preserve live transcription, selected microphone support, audio metering, finalization, and engine fallback behavior
- update FluidAudio to a revision compatible with Xcode 26.6 and adapt the Parakeet API calls
- remove the legacy Speech Recognition permission and update the documentation

## Motivation

I have used Kaze for a long time. Direct Dictation was sometimes slower and less accurate than I wanted, but it was still usable. I recently found this benchmark through Hacker News: https://get-inscribe.com/blog/apple-speech-api-benchmark.html

The benchmark reports a substantial accuracy improvement from Apple's legacy `SFSpeechRecognizer` to the newer `SpeechAnalyzer` and `SpeechTranscriber` APIs. Since Kaze already targets macOS 26, this seemed like a useful upgrade for the built-in Apple engine.

I used a coding agent with current Apple documentation and macOS build tooling to implement and review the migration. I then tested the installed Release build locally. The difference is noticeable in both responsiveness and accuracy, including Indian-accented English. Direct Dictation now feels much more competitive without requiring Kaze to ship its own speech model.

## Implementation notes

- microphone audio is buffered immediately while the analyzer prepares, so the start of short utterances is retained
- audio is converted to the analyzer's preferred format with a persistent `AVAudioConverter`
- input is drained and flushed before `finalizeAndFinishThroughEndOfInput()` completes the session
- Apple-managed model assets are installed through `AssetInventory`
- custom vocabulary remains available to Whisper and text enhancement because Apple documents contextual strings for `DictationTranscriber`, not the newer `SpeechTranscriber` model

## Testing

- Debug build with Xcode 26.6 and macOS 26.5 SDK
- Release build with Xcode 26.6 and macOS 26.5 SDK
- installed and tested the Release app locally on macOS 26
- verified live partial results and final transcription
- verified Direct Dictation with Indian-accented English
- verified the project diff contains no added em dashes or emojis
